### PR TITLE
reporthost.py: add {} to Missing:

### DIFF
--- a/libnessus/objects/reporthost.py
+++ b/libnessus/objects/reporthost.py
@@ -22,7 +22,7 @@ class NessusReportHost(object):
         else:
             raise Exception("Not all the attributes to create a decent "
                             "NessusReportHost are available. "
-                            "Missing: ".format(" ".join(_missing_attr)))
+                            "Missing: {}".format(" ".join(_missing_attr)))
 
         self.__report_items = report_items
 


### PR DESCRIPTION
without the tag, the missing attributes are not shown.
